### PR TITLE
some more dockerfile fixes

### DIFF
--- a/docker-compose-AmazonCorretoJdk11.yml
+++ b/docker-compose-AmazonCorretoJdk11.yml
@@ -16,9 +16,11 @@ services:
     env_file:
       - docker-compose-env.txt
     volumes:
-       - service-data:/opt/service/data
+       - service-config:/opt/service/config
        - service-logs:/opt/service/logs
+       - service-ssl:/opt/service/ssl
 
 volumes:
-  service-data:
+  service-config:
   service-logs:
+  service-ssl:


### PR DESCRIPTION
 FromAmazonCorrettoJdk11.Dockerfile
    fixed VOLUME instruction
    base image changed to alpine
    dockerfile optimization (-20 Mb, dive image efficiency score: 99 %)
docker-compose-AmazonCorretoJdk11.yml
    fixed volumes